### PR TITLE
use node address for removal

### DIFF
--- a/pysyncobj/syncobj.py
+++ b/pysyncobj/syncobj.py
@@ -1079,7 +1079,7 @@ class SyncObj(object):
                 if self.__nodes[i].getAddress() == oldNode:
                     self.__nodes[i]._destroy()
                     self.__nodes.pop(i)
-                    self.__otherNodesAddrs.pop(i)
+                    self.__otherNodesAddrs.remove(oldNode)
                     del self.__raftNextIndex[oldNode]
                     del self.__raftMatchIndex[oldNode]
                     return True


### PR DESCRIPTION
Use the node address when removing nodes from the `otherNodesAddrs` list instead of the index. 
The order of nodes in `__nodes` and `__otherNodesAddrs` can end up out of sync and this is safer. 

`__nodes` gets created here https://github.com/bakwc/PySyncObj/blob/master/pysyncobj/syncobj.py#L265 depending on the order of nodes passed in when created but `__otherNodesAddrs` gets reassigned here https://github.com/bakwc/PySyncObj/blob/master/pysyncobj/syncobj.py#L1173 which can be a different order. 