### PR TITLE
Network separation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ python:
   - "pypy3"
 install:
   - pip install pytest
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install cryptography; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pip install cryptography; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install cryptography coverage coveralls; fi
+  - pip install cryptography
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install coverage coveralls; fi
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coverage run --source pysyncobj -m py.test -v -l test_syncobj.py; fi
   - if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then py.test -v -l test_syncobj.py; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
 
 install:
   - "%PYTHON%\\python.exe -m pip install pytest"
+  - "%PYTHON%\\python.exe -m pip install cryptography"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,8 @@ environment:
   matrix:
 
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
 
 install:

--- a/pysyncobj/dns_resolver.py
+++ b/pysyncobj/dns_resolver.py
@@ -9,7 +9,7 @@ class DnsCachingResolver(object):
         self.__cache = {}
         self.__cacheTime = cacheTime
         self.__failCacheTime = failCacheTime
-        self.__preferedAddrFamily = socket.AF_INET
+        self.__preferredAddrFamily = socket.AF_INET
 
     def setTimeouts(self, cacheTime, failCacheTime):
         self.__cacheTime = cacheTime
@@ -35,13 +35,13 @@ class DnsCachingResolver(object):
         elif preferredAddrFamily == 'ipv6':
             self.__preferredAddrFamily = socket.AF_INET
         else:
-            self.__preferedAddrFamily = preferredAddrFamily
+            self.__preferredAddrFamily = preferredAddrFamily
 
     def __doResolve(self, hostname):
         try:
             addrs = socket.getaddrinfo(hostname, None)
             ips = []
-            if self.__preferedAddrFamily is not None:
+            if self.__preferredAddrFamily is not None:
                 ips = list(set([addr[4][0] for addr in addrs\
                                 if addr[0] == self.__preferredAddrFamily]))
             if not ips:

--- a/pysyncobj/node.py
+++ b/pysyncobj/node.py
@@ -29,6 +29,11 @@ class Node(object):
     def __eq__(self, other):
         return isinstance(other, Node) and self.id == other.id
 
+    def __ne__(self, other):
+        # In Python 3, __ne__ defaults to inverting the result of __eq__.
+        # Python 2 isn't as sane. So for Python 2 compatibility, we also need to define the != operator explicitly.
+        return not (self == other)
+
     def __hash__(self):
         return hash(self.id)
 

--- a/pysyncobj/node.py
+++ b/pysyncobj/node.py
@@ -1,114 +1,71 @@
-import weakref
-import time
-import os
-from .tcp_connection import TcpConnection
 from .dns_resolver import globalDnsResolver
-
-class NODE_STATUS:
-    DISCONNECTED = 0
-    CONNECTING = 1
-    CONNECTED = 2
 
 
 class Node(object):
+    """
+    A representation of any node in the network.
 
-    def __init__(self, syncObj, nodeAddr, shouldConnect = None):
-        self.__syncObj = weakref.ref(syncObj)
-        self.__nodeAddr = nodeAddr
+    The ID must uniquely identify a node. Node objects with the same ID will be treated as equal, i.e. as representing the same node.
+    """
 
-        if shouldConnect is not None:
-            self.__shouldConnect = shouldConnect
-        else:
-            self.__shouldConnect = syncObj._getSelfNodeAddr() > nodeAddr
+    def __init__(self, id, **kwargs):
+        """
+        Initialise the Node; id must be immutable, hashable, and unique.
 
-        self.__encryptor = syncObj._getEncryptor()
-        self.__conn = None
+        :param id: unique, immutable, hashable ID of a node
+        :type id: any
+        :param **kwargs: any further information that should be kept about this node
+        """
 
-        if self.__shouldConnect:
-            self.__ip = globalDnsResolver().resolve(nodeAddr.rsplit(':', 1)[0])
-            self.__port = int(nodeAddr.rsplit(':', 1)[1])
-            self.__conn = TcpConnection(poller=syncObj._poller,
-                                        onConnected=self.__onConnected,
-                                        onMessageReceived=self.__onMessageReceived,
-                                        onDisconnected=self.__onDisconnected,
-                                        timeout=syncObj._getConf().connectionTimeout,
-                                        sendBufferSize=syncObj._getConf().sendBufferSize,
-                                        recvBufferSize=syncObj._getConf().recvBufferSize)
-            self.__conn.encryptor = self.__encryptor
+        self._id = id
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
 
-        self.__lastConnectAttemptTime = 0
-        self.__lastPingTime = 0
-        self.__status = NODE_STATUS.DISCONNECTED
-        self.__terminating = False
+    def __setattr__(self, name, value):
+        if name == 'id':
+            raise AttributeError('Node id is not mutable')
+        super(Node, self).__setattr__(name, value)
 
-    def _destroy(self):
-        self.__shouldConnect = False
-        self.__syncObj = None
-        if self.__conn is not None:
-            self.__conn.disconnect()
-        self.__onDisconnected()
-        self.__terminating = True
+    def __eq__(self, other):
+        return isinstance(other, Node) and self.id == other.id
 
-    def __onConnected(self):
-        self.__status = NODE_STATUS.CONNECTED
-        if self.__encryptor:
-            self.__conn.recvRandKey = os.urandom(32)
-            self.__conn.send(self.__conn.recvRandKey)
-            return
-        selfAddr = self.__syncObj()._getSelfNodeAddr()
-        if selfAddr is not None:
-            self.__conn.send(selfAddr)
-        else:
-            self.__conn.send('readonly')
+    def __hash__(self):
+        return hash(self.id)
 
-    def __onDisconnected(self):
-        self.__status = NODE_STATUS.DISCONNECTED
+    def __str__(self):
+        return self.id
 
-    def __onMessageReceived(self, message):
-        if self.__encryptor and not self.__conn.sendRandKey:
-            self.__conn.sendRandKey = message
-            self.__conn.send(self.__syncObj()._getSelfNodeAddr())
-            return
+    def __repr__(self):
+        v = vars(self)
+        return '{}({}{})'.format(type(self).__name__, repr(self.id), (', ' + ', '.join('{} = {}'.format(key, repr(v[key])) for key in v if key != '_id')) if len(v) > 1 else '')
 
-        self.__syncObj()._onMessageReceived(self.__nodeAddr, message)
+    @property
+    def id(self):
+        return self._id
 
-    def onPartnerConnected(self, conn):
-        if self.__terminating:
-            return
-        self.__conn = conn
-        conn.setOnMessageReceivedCallback(self.__onMessageReceived)
-        conn.setOnDisconnectedCallback(self.__onDisconnected)
-        self.__status = NODE_STATUS.CONNECTED
 
-    def getStatus(self):
-        return self.__status
+class TCPNode(Node):
+    """
+    A node intended for communication over TCP/IP. Its id is the network address (host:port).
+    """
 
-    def isConnected(self):
-        return self.__status == NODE_STATUS.CONNECTED
+    def __init__(self, address, **kwargs):
+        """
+        Initialise the TCPNode
 
-    def getAddress(self):
-        return self.__nodeAddr
+        :param address: network address of the node in the format 'host:port'
+        :type address: str
+        :param **kwargs: any further information that should be kept about this node
+        """
 
-    def getSendBufferSize(self):
-        return self.__conn.getSendBufferSize()
+        super(TCPNode, self).__init__(address, **kwargs)
+        self.address = address
+        self.host, port = address.rsplit(':', 1)
+        self.port = int(port)
+        self.ip = globalDnsResolver().resolve(self.host)
 
-    def send(self, message):
-        if self.__status != NODE_STATUS.CONNECTED:
-            return False
-        self.__conn.send(message)
-        if self.__status != NODE_STATUS.CONNECTED:
-            return False
-        return True
-
-    def connectIfRequired(self):
-        if not self.__shouldConnect:
-            return
-        if self.__status != NODE_STATUS.DISCONNECTED:
-            return
-        if time.time() - self.__lastConnectAttemptTime < self.__syncObj()._getConf().connectionRetryTime:
-            return
-        self.__status = NODE_STATUS.CONNECTING
-        self.__lastConnectAttemptTime = time.time()
-        if not self.__conn.connect(self.__ip, self.__port):
-            self.__status = NODE_STATUS.DISCONNECTED
-            return
+    def __repr__(self):
+        v = vars(self)
+        filtered = ['_id', 'address', 'host', 'port', 'ip']
+        formatted = ['{} = {}'.format(key, repr(v[key])) for key in v if key not in filtered]
+        return '{}({}{})'.format(type(self).__name__, repr(self.id), (', ' + ', '.join(formatted)) if len(formatted) else '')

--- a/pysyncobj/syncobj.py
+++ b/pysyncobj/syncobj.py
@@ -268,8 +268,8 @@ class SyncObj(object):
                 while not self.__transport.ready:
                     self.__transport.tryGetReady()
             except TransportNotReadyError:
-                raise SyncObjException('BindError') # Backwards compatibility
                 logging.exception('failed to perform initialization')
+                raise SyncObjException('BindError') # Backwards compatibility
 
     def destroy(self):
         """

--- a/pysyncobj/tcp_connection.py
+++ b/pysyncobj/tcp_connection.py
@@ -60,6 +60,9 @@ class TcpConnection(object):
         self.__sendBufferSize = sendBufferSize
         self.__recvBufferSize = recvBufferSize
 
+    def setOnConnectedCallback(self, onConnected):
+        self.__onConnected = onConnected
+
     def setOnMessageReceivedCallback(self, onMessageReceived):
         self.__onMessageReceived = onMessageReceived
 
@@ -232,3 +235,7 @@ class TcpConnection(object):
             return None
         self.__readBuffer = self.__readBuffer[4 + l:]
         return message
+
+    @property
+    def state(self):
+        return self.__state

--- a/pysyncobj/transport.py
+++ b/pysyncobj/transport.py
@@ -1,0 +1,567 @@
+from .config import FAIL_REASON
+from .dns_resolver import globalDnsResolver
+from .node import Node, TCPNode
+from .tcp_connection import TcpConnection, CONNECTION_STATE
+from .tcp_server import TcpServer
+import functools
+import os
+import threading
+import time
+
+
+class TransportNotReadyError(Exception):
+    """Transport failed to get ready for operation."""
+
+
+class Transport(object):
+    """Base class for implementing a transport between PySyncObj nodes"""
+
+    def __init__(self, syncObj, selfNode, otherNodes):
+        """
+        Initialise the transport
+
+        :param syncObj: SyncObj
+        :type syncObj: SyncObj
+        :param selfNode: current server node, or None if this is a read-only node
+        :type selfNode: Node or None
+        :param otherNodes: partner nodes
+        :type otherNodes: list of Node
+        """
+
+        self._onMessageReceivedCallback = None
+        self._onNodeConnectedCallback = None
+        self._onNodeDisconnectedCallback = None
+        self._onReadonlyNodeConnectedCallback = None
+        self._onReadonlyNodeDisconnectedCallback = None
+
+    def setOnMessageReceivedCallback(self, callback):
+        """
+        Set the callback for when a message is received, or disable callback by passing None
+
+        :param callback callback
+        :type callback function(node: Node, message: any) or None
+        """
+
+        self._onMessageReceivedCallback = callback
+
+    def setOnNodeConnectedCallback(self, callback):
+        """
+        Set the callback for when the connection to a (non-read-only) node is established, or disable callback by passing None
+
+        :param callback callback
+        :type callback function(node: Node) or None
+        """
+
+        self._onNodeConnectedCallback = callback
+
+    def setOnNodeDisconnectedCallback(self, callback):
+        """
+        Set the callback for when the connection to a (non-read-only) node is terminated or is considered dead, or disable callback by passing None
+
+        :param callback callback
+        :type callback function(node: Node) or None
+        """
+
+        self._onNodeDisconnectedCallback = callback
+
+    def setOnReadonlyNodeConnectedCallback(self, callback):
+        """
+        Set the callback for when a read-only node connects, or disable callback by passing None
+
+        :param callback callback
+        :type callback function(node: Node) or None
+        """
+
+        self._onReadonlyNodeConnectedCallback = callback
+
+    def setOnReadonlyNodeDisconnectedCallback(self, callback):
+        """
+        Set the callback for when a read-only node disconnects (or the connection is lost), or disable callback by passing None
+
+        :param callback callback
+        :type callback function(node: Node) or None
+        """
+
+        self._onReadonlyNodeDisconnectedCallback = callback
+
+    # Helper functions so you don't need to check for the callbacks manually in subclasses
+    def _onMessageReceived(self, node, message):
+        if self._onMessageReceivedCallback is not None:
+            self._onMessageReceivedCallback(node, message)
+
+    def _onNodeConnected(self, node):
+        if self._onNodeConnectedCallback is not None:
+            self._onNodeConnectedCallback(node)
+
+    def _onNodeDisconnected(self, node):
+        if self._onNodeDisconnectedCallback is not None:
+            self._onNodeDisconnectedCallback(node)
+
+    def _onReadonlyNodeConnected(self, node):
+        if self._onReadonlyNodeConnectedCallback is not None:
+            self._onReadonlyNodeConnectedCallback(node)
+
+    def _onReadonlyNodeDisconnected(self, node):
+        if self._onReadonlyNodeDisconnectedCallback is not None:
+            self._onReadonlyNodeDisconnectedCallback(node)
+
+    def tryGetReady(self):
+        """
+        Try to get the transport ready for operation. This may for example mean binding a server to a port.
+
+        :raises TransportNotReadyError: if the transport fails to get ready for operation
+        """
+
+    @property
+    def ready(self):
+        """
+        Whether the transport is ready for operation.
+
+        :rtype bool
+        """
+
+        return True
+
+    def waitReady(self):
+        """
+        Wait for the transport to be ready.
+
+        :raises TransportNotReadyError: if the transport fails to get ready for operation
+        """
+
+    def addNode(self, node):
+        """
+        Add a node to the network
+
+        :param node node to add
+        :type node Node
+        """
+
+    def dropNode(self, node):
+        """
+        Remove a node from the network (meaning connections, buffers, etc. related to this node can be dropped)
+
+        :param node node to drop
+        :type node Node
+        """
+
+    def send(self, node, message):
+        """
+        Send a message to a node.
+        The message should be picklable.
+        The return value signifies whether the message is thought to have been sent successfully. It does not necessarily mean that the message actually arrived at the node.
+
+        :param node target node
+        :type node Node
+        :param message message
+        :type message any
+        :returns success
+        :rtype bool
+        """
+
+        raise NotImplementedError
+
+    def destroy(self):
+        """
+        Destroy the transport
+        """
+
+
+class TCPTransport(Transport):
+    def __init__(self, syncObj, selfNode, otherNodes):
+        """
+        Initialise the TCP transport. On normal (non-read-only) nodes, this will start a TCP server. On all nodes, it will initiate relevant connections to other nodes.
+
+        :param syncObj: SyncObj
+        :type syncObj: SyncObj
+        :param selfNode: current node (None if this is a read-only node)
+        :type selfNode: TCPNode or None
+        :param otherNodes: partner nodes
+        :type otherNodes: iterable of TCPNode
+        """
+
+        super(TCPTransport, self).__init__(syncObj, selfNode, otherNodes)
+        self._syncObj = syncObj
+        self._server = None
+        self._connections = {} # Node object -> TcpConnection object
+        self._unknownConnections = set() # set of TcpConnection objects
+        self._selfNode = selfNode
+        self._selfIsReadonlyNode = selfNode is None
+        self._nodes = set() # set of TCPNode
+        self._readonlyNodes = set() # set of Node
+        self._nodeAddrToNode = {} # node ID/address -> TCPNode (does not include read-only nodes)
+        self._lastConnectAttempt = {} # TPCNode -> float (seconds since epoch)
+        self._preventConnectNodes = set() # set of TCPNode to which no (re)connection should be triggered on _connectIfNecessary; used via dropNode and destroy to cleanly remove a node
+        self._readonlyNodesCounter = 0
+        self._lastBindAttemptTime = 0
+        self._bindAttempts = 0
+        self._bindOverEvent = threading.Event() # gets triggered either when the server has either been bound correctly or when the number of bind attempts exceeds the config value maxBindRetries
+        self._ready = False
+
+        self._syncObj.addOnTickCallback(self._onTick)
+
+        for node in otherNodes:
+            self.addNode(node)
+
+        if not self._selfIsReadonlyNode:
+            self._createServer()
+        else:
+            self._ready = True
+
+    def _connToNode(self, conn):
+        """
+        Find the node to which a connection belongs.
+
+        :param conn: connection object
+        :type conn: TcpConnection
+        :returns corresponding node or None if the node cannot be found
+        :rtype Node or None
+        """
+
+        for node in self._connections:
+            if self._connections[node] is conn:
+                return node
+        return None
+
+    def tryGetReady(self):
+        """
+        Try to bind the server if necessary.
+
+        :raises TransportNotReadyError if the server could not be bound
+        """
+
+        self._maybeBind()
+
+    @property
+    def ready(self):
+        return self._ready
+
+    def _createServer(self):
+        """
+        Create the TCP server (but don't bind yet)
+        """
+
+        conf = self._syncObj.conf
+        bindAddr = conf.bindAddress or getattr(self._selfNode, 'address')
+        if not bindAddr:
+            raise RuntimeError('Unable to determine bind address')
+        host, port = bindAddr.rsplit(':', 1)
+        host = globalDnsResolver().resolve(host)
+        self._server = TcpServer(self._syncObj._poller, host, port, onNewConnection = self._onNewIncomingConnection,
+                                 sendBufferSize = conf.sendBufferSize,
+                                 recvBufferSize = conf.recvBufferSize,
+                                 connectionTimeout = conf.connectionTimeout)
+
+    def _maybeBind(self):
+        """
+        Bind the server unless it is already bound, this is a read-only node, or the last attempt was too recently.
+
+        :raises TransportNotReadyError if the bind attempt fails
+        """
+
+        if self._ready or self._selfIsReadonlyNode or time.time() < self._lastBindAttemptTime + self._syncObj.conf.bindRetryTime:
+            return
+        self._lastBindAttemptTime = time.time()
+        try:
+            self._server.bind()
+        except Exception as e:
+            self._bindAttempts += 1
+            if self._syncObj.conf.maxBindRetries and self._bindAttempts >= self._syncObj.conf.maxBindRetries:
+                self._bindOverEvent.set()
+                raise TransportNotReadyError
+        else:
+            self._ready = True
+            self._bindOverEvent.set()
+
+    def _onTick(self):
+        """
+        Tick callback. Binds the server and connects to other nodes as necessary.
+        """
+
+        try:
+            self._maybeBind()
+        except TransportNotReadyError:
+            pass
+        self._connectIfNecessary()
+
+    def _onNewIncomingConnection(self, conn):
+        """
+        Callback for connections initiated by the other side
+
+        :param conn: connection object
+        :type conn: TcpConnection
+        """
+
+        self._unknownConnections.add(conn)
+        encryptor = self._syncObj.encryptor
+        if encryptor:
+            conn.encryptor = encryptor
+        conn.setOnMessageReceivedCallback(functools.partial(self._onIncomingMessageReceived, conn))
+        conn.setOnDisconnectedCallback(functools.partial(self._onDisconnected, conn))
+
+    def _onIncomingMessageReceived(self, conn, message):
+        """
+        Callback for initial messages on incoming connections. Handles encryption, utility messages, and association of the connection with a Node.
+        Once this initial setup is done, the relevant connected callback is executed, and further messages are deferred to the onMessageReceived callback.
+
+        :param conn: connection object
+        :type conn: TcpConnection
+        :param message: received message
+        :type message: any
+        """
+
+        if self._syncObj.encryptor and not conn.sendRandKey:
+            conn.sendRandKey = message
+            conn.recvRandKey = os.urandom(32)
+            conn.send(conn.recvRandKey)
+            return
+
+        # Utility messages
+        if isinstance(message, list):
+            done = False
+            try:
+                if message[0] == 'status':
+                    conn.send(self._syncObj.getStatus())
+                    done = True
+                elif message[0] == 'add':
+                    self._syncObj.addNodeToCluster(message[1], callback = functools.partial(self._utilityCallback, conn = conn, cmd = 'ADD', arg = message[1]))
+                    done = True
+                elif message[0] == 'remove':
+                    if message[1] == self._selfNode.address:
+                        conn.send('FAIL REMOVE ' + message[1])
+                    else:
+                        self._syncObj.removeNodeFromCluster(message[1], callback = functools.partial(self._utilityCallback, conn = conn, cmd = 'REMOVE', arg = message[1]))
+                    done = True
+                elif message[0] == 'set_version':
+                    self._syncObj.setCodeVersion(message[1], callback = functools.partial(self._utilityCallback, conn = conn, cmd = 'SET_VERSION', arg = str(message[1])))
+                    done = True
+            except Exception as e:
+                conn.send(str(e))
+                done = True
+            if done:
+                return
+
+        # At this point, message should be either a node ID (i.e. address) or 'readonly'
+        node = self._nodeAddrToNode[message] if message in self._nodeAddrToNode else None
+
+        if node is None and message != 'readonly':
+            conn.disconnect()
+            self._unknownConnections.discard(conn)
+            return
+
+        readonly = node is None
+        if readonly:
+            nodeId = str(self._readonlyNodesCounter)
+            node = Node(nodeId)
+            self._readonlyNodes.add(node)
+            self._readonlyNodesCounter += 1
+
+        self._unknownConnections.discard(conn)
+        self._connections[node] = conn
+        conn.setOnMessageReceivedCallback(functools.partial(self._onMessageReceived, node))
+        if not readonly:
+            self._onNodeConnected(node)
+        else:
+            self._onReadonlyNodeConnected(node)
+
+    def _utilityCallback(self, res, err, conn, cmd, arg):
+        """
+        Callback for the utility messages
+
+        :param res: result of the command
+        :param err: error code (one of pysyncobj.config.FAIL_REASON)
+        :param conn: utility connection
+        :param cmd: command
+        :param arg: command arguments
+        """
+
+        cmdResult = 'FAIL'
+        if err == FAIL_REASON.SUCCESS:
+            cmdResult = 'SUCCESS'
+        conn.send(cmdResult + ' ' + cmd + ' ' + arg)
+
+    def _shouldConnect(self, node):
+        """
+        Check whether this node should initiate a connection to another node
+
+        :param node: the other node
+        :type node: Node
+        """
+
+        return isinstance(node, TCPNode) and node not in self._preventConnectNodes and (self._selfIsReadonlyNode or self._selfNode.address > node.address)
+
+    def _connectIfNecessarySingle(self, node):
+        """
+        Connect to a node if necessary.
+
+        :param node: node to connect to
+        :type node: Node
+        """
+
+        if node in self._connections and self._connections[node].state != CONNECTION_STATE.DISCONNECTED:
+            return True
+        if not self._shouldConnect(node):
+            return False
+        assert node in self._connections # Since we "should connect" to this node, there should always be a connection object already in place.
+        if node in self._lastConnectAttempt and time.time() - self._lastConnectAttempt[node] < self._syncObj.conf.connectionRetryTime:
+            return False
+        self._lastConnectAttempt[node] = time.time()
+        return self._connections[node].connect(node.ip, node.port)
+
+    def _connectIfNecessary(self):
+        """
+        Connect to all nodes as necessary.
+        """
+
+        for node in self._nodes:
+            self._connectIfNecessarySingle(node)
+
+    def _onOutgoingConnected(self, conn):
+        """
+        Callback for when a new connection from this to another node is established. Handles encryption and informs the other node which node this is.
+        If encryption is disabled, this triggers the onNodeConnected callback and messages are deferred to the onMessageReceived callback.
+        If encryption is enabled, the first message is handled by _onOutgoingMessageReceived.
+
+        :param conn: connection object
+        :type conn: TcpConnection
+        """
+
+        if self._syncObj.encryptor:
+            conn.setOnMessageReceivedCallback(functools.partial(self._onOutgoingMessageReceived, conn)) # So we can process the sendRandKey
+            conn.recvRandKey = os.urandom(32)
+            conn.send(self.__conn.recvRandKey)
+        else:
+            # The onMessageReceived callback is configured in addNode already.
+            if not self._selfIsReadonlyNode:
+                conn.send(self._selfNode.address)
+            else:
+                conn.send('readonly')
+            self._onNodeConnected(self._connToNode(conn))
+
+    def _onOutgoingMessageReceived(self, conn, message):
+        """
+        Callback for receiving a message on a new outgoing connection. Used only if encryption is enabled to exchange the random keys.
+        Once the key exchange is done, this triggers the onNodeConnected callback, and further messages are deferred to the onMessageReceived callback.
+
+        :param conn: connection object
+        :type conn: TcpConnection
+        :param message: received message
+        :type message: any
+        """
+
+        if not conn.sendRandKey:
+            conn.sendRandKey = message
+            conn.send(self._selfNode.address)
+
+        node = self._connToNode(conn)
+        conn.setOnMessageReceivedCallback(functools.partial(self._onMessageReceived, node))
+        self._onNodeConnected(node)
+
+    def _onDisconnected(self, conn):
+        """
+        Callback for when a connection is terminated or considered dead. Initiates a reconnect if necessary.
+
+        :param conn: connection object
+        :type conn: TcpConnection
+        """
+
+        self._unknownConnections.discard(conn)
+        node = self._connToNode(conn)
+        if node is not None:
+            if node in self._nodes:
+                self._onNodeDisconnected(node)
+                self._connectIfNecessarySingle(node)
+            else:
+                self._readonlyNodes.discard(node)
+                self._onReadonlyNodeDisconnected(node)
+
+    def waitReady(self):
+        """
+        Wait for the TCP transport to become ready for operation, i.e. the server to be bound.
+        This method should be called from a different thread than used for the SyncObj ticks.
+
+        :raises TransportNotReadyError: if the number of bind tries exceeds the configured limit
+        """
+
+        self._bindOverEvent.wait()
+        if not self._ready:
+            raise TransportNotReadyError
+
+    def addNode(self, node):
+        """
+        Add a node to the network
+
+        :param node: node to add
+        :type node: TCPNode
+        """
+
+        self._nodes.add(node)
+        self._nodeAddrToNode[node.address] = node
+        if self._shouldConnect(node):
+            conn = TcpConnection(poller = self._syncObj._poller,
+                                 timeout = self._syncObj.conf.connectionTimeout,
+                                 sendBufferSize = self._syncObj.conf.sendBufferSize,
+                                 recvBufferSize = self._syncObj.conf.recvBufferSize)
+            conn.encryptor = self._syncObj.encryptor
+            conn.setOnConnectedCallback(functools.partial(self._onOutgoingConnected, conn))
+            conn.setOnMessageReceivedCallback(functools.partial(self._onMessageReceived, node))
+            conn.setOnDisconnectedCallback(functools.partial(self._onDisconnected, conn))
+            self._connections[node] = conn
+
+    def dropNode(self, node):
+        """
+        Drop a node from the network
+
+        :param node: node to drop
+        :type node: Node
+        """
+
+        conn = self._connections.pop(node, None)
+        if conn is not None:
+            # Calling conn.disconnect() immediately triggers the onDisconnected callback if the connection isn't already disconnected, so this is necessary to prevent the automatic reconnect.
+            self._preventConnectNodes.add(node)
+            conn.disconnect()
+            self._preventConnectNodes.remove(node)
+        if isinstance(node, TCPNode):
+            self._nodes.discard(node)
+            self._nodeAddrToNode.pop(node.address, None)
+        else:
+            self._readonlyNodes.discard(node)
+        self._lastConnectAttempt.pop(node, None)
+
+    def send(self, node, message):
+        """
+        Send a message to a node. Returns False if the connection appears to be dead either before or after actually trying to send the message.
+
+        :param node: target node
+        :type node: Node
+        :param message: message
+        :param message: any
+        :returns success
+        :rtype bool
+        """
+
+        if node not in self._connections or self._connections[node].state != CONNECTION_STATE.CONNECTED:
+            return False
+        self._connections[node].send(message)
+        if self._connections[node].state != CONNECTION_STATE.CONNECTED:
+            return False
+        return True
+
+    def destroy(self):
+        """
+        Destroy this transport
+        """
+
+        self.setOnMessageReceivedCallback(None)
+        self.setOnNodeConnectedCallback(None)
+        self.setOnNodeDisconnectedCallback(None)
+        self.setOnReadonlyNodeConnectedCallback(None)
+        self.setOnReadonlyNodeDisconnectedCallback(None)
+        for node in self._nodes | self._readonlyNodes:
+            self.dropNode(node)
+        if self._server is not None:
+            self._server.unbind()
+        for conn in self._unknownConnections:
+            conn.disconnect()
+        self._unknownConnections = set()

--- a/pysyncobj/transport.py
+++ b/pysyncobj/transport.py
@@ -429,7 +429,7 @@ class TCPTransport(Transport):
         if self._syncObj.encryptor:
             conn.setOnMessageReceivedCallback(functools.partial(self._onOutgoingMessageReceived, conn)) # So we can process the sendRandKey
             conn.recvRandKey = os.urandom(32)
-            conn.send(self.__conn.recvRandKey)
+            conn.send(conn.recvRandKey)
         else:
             # The onMessageReceived callback is configured in addNode already.
             if not self._selfIsReadonlyNode:

--- a/test_syncobj.py
+++ b/test_syncobj.py
@@ -1133,7 +1133,7 @@ def test_largeCommands():
 	a = [getNextAddr(), getNextAddr()]
 
 	o1 = TestObj(a[0], [a[1]], TEST_TYPE.LARGE_COMMAND, dumpFile = dumpFiles[0], leaderFallbackTimeout=60.0)
-	o2 = TestObj(a[1], [a[0]], TEST_TYPE.LARGE_COMMAND, dumpFile = dumpFiles[0], leaderFallbackTimeout=60.0)
+	o2 = TestObj(a[1], [a[0]], TEST_TYPE.LARGE_COMMAND, dumpFile = dumpFiles[1], leaderFallbackTimeout=60.0)
 	objs = [o1, o2]
 	doTicks(objs, 10, stopFunc=lambda: o1._isReady() and o2._isReady())
 

--- a/test_syncobj.py
+++ b/test_syncobj.py
@@ -15,6 +15,7 @@ import logging
 from pysyncobj import SyncObj, SyncObjConf, replicated, FAIL_REASON, _COMMAND_TYPE, \
 	createJournal, HAS_CRYPTO, replicated_sync, Utility, SyncObjException, SyncObjConsumer, _RAFT_STATE
 from pysyncobj.batteries import ReplCounter, ReplList, ReplDict, ReplSet, ReplLockManager, ReplQueue, ReplPriorityQueue
+from pysyncobj.node import TCPNode
 from collections import defaultdict
 
 logging.basicConfig(format = u'[%(asctime)s %(filename)s:%(lineno)d %(levelname)s]  %(message)s', level = logging.DEBUG)
@@ -240,7 +241,7 @@ def test_syncTwoObjects():
 
 	o1._printStatus()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 	assert o1._isReady()
 	assert o2._isReady()
@@ -274,7 +275,7 @@ def test_singleObject():
 
 	o1._printStatus()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._isReady()
 
 	o1.addValue(150)
@@ -311,11 +312,11 @@ def test_syncThreeObjectsLeaderFail():
 	assert o2._isReady()
 	assert o3._isReady()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 	assert o1._getLeader() == o3._getLeader()
 
-	assert _RAFT_STATE.LEADER in states[o1._getLeader()]
+	assert _RAFT_STATE.LEADER in states[o1._getLeader().address]
 
 	o1.addValue(150)
 	o2.addValue(200)
@@ -326,19 +327,20 @@ def test_syncThreeObjectsLeaderFail():
 
 	prevLeader = o1._getLeader()
 
-	newObjs = [o for o in objs if o._getSelfNodeAddr() != prevLeader]
+	newObjs = [o for o in objs if o._SyncObj__selfNode != prevLeader]
 
 	assert len(newObjs) == 2
 
 	doTicks(newObjs, 10.0, stopFunc=lambda: newObjs[0]._getLeader() != prevLeader and \
-											newObjs[0]._getLeader() in a and \
+											newObjs[0]._getLeader() is not None and \
+											newObjs[0]._getLeader().address in a and \
 											newObjs[0]._getLeader() == newObjs[1]._getLeader())
 
 	assert newObjs[0]._getLeader() != prevLeader
-	assert newObjs[0]._getLeader() in a
+	assert newObjs[0]._getLeader().address in a
 	assert newObjs[0]._getLeader() == newObjs[1]._getLeader()
 
-	assert _RAFT_STATE.LEADER in states[newObjs[0]._getLeader()]
+	assert _RAFT_STATE.LEADER in states[newObjs[0]._getLeader().address]
 
 	newObjs[1].addValue(50)
 
@@ -376,7 +378,7 @@ def test_manyActionsLogCompaction():
 	assert o2._isReady()
 	assert o3._isReady()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 	assert o1._getLeader() == o3._getLeader()
 
@@ -449,7 +451,7 @@ def test_checkCallbacksSimple():
 	assert o2._isReady()
 	assert o3._isReady()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 	assert o1._getLeader() == o3._getLeader()
 
@@ -496,7 +498,7 @@ def checkDumpToFile(useFork):
 	objs = [o1, o2]
 	doTicks(objs, 10, stopFunc=lambda: o1._isReady() and o2._isReady())
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	o1.addValue(150)
@@ -523,7 +525,7 @@ def checkDumpToFile(useFork):
 	assert o1._isReady()
 	assert o2._isReady()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	assert o1.getCounter() == 350
@@ -557,7 +559,7 @@ def test_checkBigStorage():
 	objs = [o1, o2]
 	doTicks(objs, 10, stopFunc=lambda: o1._isReady() and o2._isReady())
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	# Store ~50Mb data.
@@ -589,7 +591,7 @@ def test_checkBigStorage():
 	# Wait for disk load, election and replication
 	doTicks(objs, 10, stopFunc=lambda: o1._isReady() and o2._isReady())
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	assert o1.getValue('test') == testRandStr
@@ -614,7 +616,7 @@ def test_encryptionCorrectPassword():
 	objs = [o1, o2]
 	doTicks(objs, 10, stopFunc=lambda: o1._isReady() and o2._isReady())
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	o1.addValue(150)
@@ -644,7 +646,7 @@ def test_encryptionWrongPassword():
 
 	doTicks(objs, 10, stopFunc=lambda: o1._isReady() and o2._isReady())
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	doTicks(objs, 1.0)
@@ -658,12 +660,12 @@ def test_encryptionWrongPassword():
 def _checkSameLeader(objs):
 	for obj1 in objs:
 		l1 = obj1._getLeader()
-		if l1 != obj1._getSelfNodeAddr():
+		if l1 != obj1._SyncObj__selfNode:
 			continue
 		t1 = obj1._getTerm()
 		for obj2 in objs:
 			l2 = obj2._getLeader()
-			if l2 != obj2._getSelfNodeAddr():
+			if l2 != obj2._SyncObj__selfNode:
 				continue
 			if obj2._getTerm() != t1:
 				continue
@@ -779,7 +781,7 @@ def test_logCompactionRegressionTest1():
 
 	doTicks(objs, 10, stopFunc=lambda: o1._isReady() and o2._isReady())
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	o1._forceLogCompaction()
@@ -816,7 +818,7 @@ def test_logCompactionRegressionTest2():
 	o3._forceLogCompaction()
 	doTicks(objs, 0.5)
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader() == o3._getLeader()
 
 	o3._destroy()
@@ -846,25 +848,10 @@ def test_logCompactionRegressionTest2():
 	removeFiles(dumpFiles)
 
 
-def __checkParnerNodeExists(obj, nodeName, shouldExist = True):
-	nodesSet1 = set()
-	nodesSet2 = set(obj._SyncObj__otherNodesAddrs)
-	for node in obj._SyncObj__nodes:
-		nodesSet1.add(node.getAddress())
+def __checkParnerNodeExists(obj, nodeAddr, shouldExist = True):
+	nodeAddrSet = {node.address for node in obj._SyncObj__otherNodes}
+	return (nodeAddr in nodeAddrSet) == shouldExist # either nodeAddr is in nodeAddrSet and shouldExist is True, or nodeAddr isn't in the set and shouldExist is False
 
-	if nodesSet1 != nodesSet2:
-		print('otherNodes:', nodesSet2)
-		print('nodes:', nodesSet1)
-		return False
-
-	if shouldExist:
-		#assert nodeName in nodesSet1
-		if nodeName not in nodesSet1:
-			return False
-	else:
-		if nodeName in nodesSet1:
-			return False
-	return True
 
 def test_doChangeClusterUT1():
 	dumpFiles = [getNextDumpFile()]
@@ -882,7 +869,7 @@ def test_doChangeClusterUT1():
 	member = _bchr(_COMMAND_TYPE.MEMBERSHIP)
 
 	# Check regular configuration change - adding
-	o1._onMessageReceived('localhost:12345', {
+	o1._SyncObj__onMessageReceived(TCPNode('localhost:12345'), {
 		'type': 'append_entries',
 		'term': 1,
 		'prevLogIdx': 1,
@@ -894,7 +881,7 @@ def test_doChangeClusterUT1():
 	__checkParnerNodeExists(o1, 'localhost:1239', False)
 
 	# Check rollback adding
-	o1._onMessageReceived('localhost:1236', {
+	o1._SyncObj__onMessageReceived(TCPNode('localhost:1236'), {
 		'type': 'append_entries',
 		'term': 2,
 		'prevLogIdx': 2,
@@ -907,7 +894,7 @@ def test_doChangeClusterUT1():
 	__checkParnerNodeExists(o1, oterAddr, True)
 
 	# Check regular configuration change - removing
-	o1._onMessageReceived('localhost:1236', {
+	o1._SyncObj__onMessageReceived(TCPNode('localhost:1236'), {
 		'type': 'append_entries',
 		'term': 2,
 		'prevLogIdx': 4,
@@ -994,7 +981,7 @@ def test_journalTest1():
 	objs = [o1, o2]
 	doTicks(objs, 10, stopFunc=lambda: o1._isReady() and o2._isReady())
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	o1.addValue(150)
@@ -1017,7 +1004,7 @@ def test_journalTest1():
 	assert o1._isReady()
 	assert o2._isReady()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	assert o1.getCounter() == 350
@@ -1056,7 +1043,7 @@ def test_journalTest1():
 	assert o1._isReady()
 	assert o2._isReady()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	assert o1.getCounter() == 900
@@ -1115,7 +1102,7 @@ def test_autoTick1():
 	assert o1._isReady()
 	assert o2._isReady()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 	assert o1._isReady()
 	assert o2._isReady()
@@ -1152,7 +1139,7 @@ def test_largeCommands():
 	objs = [o1, o2]
 	doTicks(objs, 10, stopFunc=lambda: o1._isReady() and o2._isReady())
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	# Generate ~20Mb data.
@@ -1194,7 +1181,7 @@ def test_largeCommands():
 									   o2.getValue('big') == bigStr and \
 									   o1._isReady() and o2._isReady())
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 
 	assert o1.getValue('test') == testRandStr
@@ -1238,20 +1225,21 @@ def test_readOnlyNodes():
 
 	assert b1.getCounter() == b2.getCounter() == 350
 	assert o1._getLeader() == b1._getLeader() == o2._getLeader() == b2._getLeader()
-	assert b1._getLeader() in a
+	assert b1._getLeader().address in a
 
 	prevLeader = o1._getLeader()
 
-	newObjs = [o for o in objs if o._getSelfNodeAddr() != prevLeader]
+	newObjs = [o for o in objs if o._SyncObj__selfNode != prevLeader]
 
 	assert len(newObjs) == 2
 
 	doTicks(newObjs + roObjs, 10.0, stopFunc=lambda: newObjs[0]._getLeader() != prevLeader and \
-											newObjs[0]._getLeader() in a and \
+											newObjs[0]._getLeader() is not None and \
+											newObjs[0]._getLeader().address in a and \
 											newObjs[0]._getLeader() == newObjs[1]._getLeader())
 
 	assert newObjs[0]._getLeader() != prevLeader
-	assert newObjs[0]._getLeader() in a
+	assert newObjs[0]._getLeader().address in a
 	assert newObjs[0]._getLeader() == newObjs[1]._getLeader()
 
 	newObjs[1].addValue(50)
@@ -1541,7 +1529,7 @@ def test_consumers():
 
 	doTicks(objs, 10.0, stopFunc=lambda: o1._isReady() and o2._isReady())
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 	assert o1._isReady()
 	assert o2._isReady()
@@ -1822,7 +1810,7 @@ def test_ipv6():
 	assert o1._isReady()
 	assert o2._isReady()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 	assert o1._isReady()
 	assert o2._isReady()
@@ -1861,7 +1849,7 @@ def test_localhost():
 
 	o1._printStatus()
 
-	assert o1._getLeader() in a
+	assert o1._getLeader().address in a
 	assert o1._getLeader() == o2._getLeader()
 	assert o1._isReady()
 	assert o2._isReady()

--- a/test_syncobj.py
+++ b/test_syncobj.py
@@ -604,8 +604,7 @@ def test_checkBigStorage():
 
 
 def test_encryptionCorrectPassword():
-	if not HAS_CRYPTO:
-		return
+	assert HAS_CRYPTO
 
 	random.seed(42)
 
@@ -632,8 +631,7 @@ def test_encryptionCorrectPassword():
 
 
 def test_encryptionWrongPassword():
-	if not HAS_CRYPTO:
-		return
+	assert HAS_CRYPTO
 
 	random.seed(12)
 
@@ -1283,8 +1281,7 @@ def test_readOnlyNodes():
 	b2._destroy()
 
 def test_syncobjAdminStatus():
-	if not HAS_CRYPTO:
-		return
+	assert HAS_CRYPTO
 
 	random.seed(42)
 


### PR DESCRIPTION
Currently, the SyncObj code is tightly coupled to the TCP transport, and it's not – or at least not easily – possible to replace this. This means that for example it's not possible to switch to UDP (#81) or to implement a fuzz test (mentioned in <https://github.com/bakwc/PySyncObj/issues/4#issue-146164631>).

This PR fixes that by moving the entire network code into a new module `pysyncobj.transport`. `SyncObj` no longer knows what's going on at the network level at all. It uses a `Transport` object for sending messages to and receiving them from other nodes. This `Transport` class can be subclassed and passed into `SyncObj` (new `transportClass` argument) for custom transports. Nodes are represented by `Node` objects, which have an `id` attribute which uniquely identifies a node and any other attributes that may be of importance to the specific transport. `SyncObj.__init__`, `addNodeToCluster`, and `removeNodeFromCluster` now take `Node` objects as arguments. You can also specify a `nodeClass` when initialising the `SyncObj`, and this class will be used to create `Node` objects if something else is passed into those methods.

The default transport and node classes are `TCPTransport` and `TCPNode`. The "node ID" used here is simply the network address as before, i.e. a string `'host:port'`. (Read-only nodes are represented by plain `Node` objects with a numeric string ID.) This means that code written for previous versions of PySyncObj does not require any changes.

There are however some subtle changes:
* Timing of connections is changed slightly. If a connection fails, the reconnection is triggered immediately rather than on the next tick.
* The previous `SyncObj` code never actually removed read-only nodes after they disconnected. The relevant code at the end of `onTick` did filter out the disconnected nodes every second, but it didn't overwrite `self.__readonlyNodes`, so they were always kept until calling `destroy()`.
    * `TCPTransport` will immediately drop read-only nodes when they disconnect (or the connection is considered dead) and inform `SyncObj` about this through the `onReadonlyNodeDisconnected` callback.
    * If the node then reconnects, it will be represented by a new `Node` object and therefore look like a completely unrelated node to all code. However, this is mostly an implementation detail; a very similar thing should have happend already in the old code, though I never tested it.
* `SyncObj.getStatus()` doesn't return the number of unknown connections anymore (field `unknown_connections_count`). This is because `SyncObj` doesn't have any concept of "unknown connections" anymore as it was moved entirely to the transport. `SyncObj` only learns about a connection from `TCPTransport` when the node has been identified and everything is ready for normal communication (through the `onNodeConnected` and `onReadonlyNodeConnected` callbacks)
    * For the same reason, `SyncObj` doesn't know (or care) whether a node is disconnected or connecting. Any node that isn't currently connected is seen as disconnected by `SyncObj`. As such, the `partner_node_status_server_X` and `readonly_node_status_server_X` fields in the dict returned by `SyncObj.getStatus()` can now only have the values zero (= disconnected) or two (= connected). These values are retained merely for backwards compatibility; it would be cleaner to replace the fields with simple booleans specifying whether the node is connected or not, `{partner,readonly}_node_connected_server_X`.
* Currently, to add/remove a node to/from the cluster, only the node ID is passed to the other nodes. In the new code, the node object is transferred as well.
    * The reasoning behind transferring the node object is that more information than just the node ID might be necessary for node identification; for example, to implement TLS, you may want to have both the network address and the certificate fingerprint as identifiers.
* The other nodes are now stored in `SyncObj` in a set instead of a list. Although this might have small effects on timing (the messages may be sent out in a different order), `PySyncObj` never guaranteed that the order of the nodes as passed into `__init__` is preserved or has any significance as far as I can see, and an application should anyway never depend on that order (since order changes can also happen due to network delays or dropped packets). (Cf #60)
    * Using sets makes the intent clearer and facilitates removing entries without an exception if the entry is not present; with lists, each such attempt must be wrapped in a `try ... except ValueError: pass`.

I also had to fix a typo in the DNS resolver which led to crashes because the `setPreferredAddrFamily` is called from `SyncObj`, not `TCPTransport`, and only after initialising the transport.

This code was tested against master (63ae9d6) with the script in PR #91. Despite the small differences listed above, everything is backward-compatible in the sense that the old and new codes can interact freely with each other. However, the new code cannot use the new functionality (e.g. replacing the transport or node classes) until all nodes are updated to the new PySyncObj code, otherwise the nodes still using the old version will most likely crash with a variety of errors (e.g. due to the `Node` objects being sent over the wire when adding or removing nodes).

As mentioned also in #91, **log compaction/dump files on upgrades are untested**. I think it should work, but I wasn't able to test it.