### PR TITLE
Fix persistence and add automatic journal flushing

### DIFF
--- a/pysyncobj/config.py
+++ b/pysyncobj/config.py
@@ -115,7 +115,13 @@ class SyncObjConf(object):
         self.fullDumpFile = kwargs.get('fullDumpFile', None)
 
         #: File to store operations journal. Save each record as soon as received.
+        #: If unspecified or None, an in-memory journal is used.
         self.journalFile = kwargs.get('journalFile', None)
+
+        #: Flush the journal whenever something is written to it.
+        #: Enabled by default if a journalFile is used.
+        #: Cannot be enabled if the journalFile is unspecified (i.e. when the journal is not preserved).
+        self.flushJournal = kwargs.get('flushJournal', None)
 
         #: Will try to bind port every bindRetryTime seconds until success.
         self.bindRetryTime = kwargs.get('bindRetryTime', 1.0)
@@ -179,6 +185,7 @@ class SyncObjConf(object):
         assert self.logCompactionMinEntries >= 2
         assert self.logCompactionMinTime > 0
         assert self.logCompactionBatchSize > 0
+        assert self.journalFile is not None or not self.flushJournal, 'flushJournal cannot be enabled without specifying a journal file'
         assert self.bindRetryTime > 0
         assert (self.deserializer is None) == (self.serializer is None)
         if self.serializer is not None:

--- a/pysyncobj/journal.py
+++ b/pysyncobj/journal.py
@@ -81,7 +81,7 @@ class ResizableFile(object):
     def write(self, offset, values):
         size = len(values)
         currSize = self.__mm.size()
-        if offset + size > self.__mm.size():
+        while offset + size > self.__mm.size():
             try:
                 self.__mm.resize(int(self.__mm.size() * self.__resizeFactor))
             except SystemError:

--- a/pysyncobj/journal.py
+++ b/pysyncobj/journal.py
@@ -1,7 +1,10 @@
+import hashlib
 import os
 import mmap
+import pickle
 import struct
 
+from .atomic_replace import atomicReplace
 from .version import VERSION
 from .pickle import to_bytes
 
@@ -106,7 +109,7 @@ class ResizableFile(object):
 
 
 
-JOURNAL_FORMAT_VERSION = 1
+JOURNAL_FORMAT_VERSION = 2
 APP_NAME = b'PYSYNCOBJ'
 APP_VERSION = str.encode(VERSION)
 
@@ -114,20 +117,62 @@ NAME_SIZE = 24
 VERSION_SIZE = 8
 assert len(APP_NAME) < NAME_SIZE
 assert len(APP_VERSION) < VERSION_SIZE
-FIRST_RECORD_OFFSET = NAME_SIZE + VERSION_SIZE + 4 + 4
-LAST_RECORD_OFFSET_OFFSET = NAME_SIZE + VERSION_SIZE + 4
+CURRENT_TERM_SIZE = 8
+VOTED_FOR_SIZE = 16
+FIRST_RECORD_OFFSET = NAME_SIZE + VERSION_SIZE + 4 + CURRENT_TERM_SIZE + VOTED_FOR_SIZE + 4
+LAST_RECORD_OFFSET_OFFSET = NAME_SIZE + VERSION_SIZE + 4 + CURRENT_TERM_SIZE + VOTED_FOR_SIZE
 
-#
-#  APP_NAME (24b) + APP_VERSION (8b) + FORMAT_VERSION (4b) + LAST_RECORD_OFFSET (4b) +
-#      record1size + record1 + record1size   +  record2size + record2 + record2size   +  ...
-#                (record1)                   |               (record2)                |  ...
-#
+# Journal version 2:
+#   APP_NAME (24b) + APP_VERSION (8b) + FORMAT_VERSION (4b) + CURRENT_TERM (8b) + VOTED_FOR (16b) + LAST_RECORD_OFFSET (4b) +
+#       record1size + record1 + record1size   +  record2size + record2 + record2size   +  ...
+#                 (record1)                   |               (record2)                |  ...
+
+# VOTED_FOR is an MD5 hash of the pickled node ID.
+# LAST_RECORD_OFFSET is the offset from the beginning of the journal file at which the last record ends.
+
+# Version 1 is identical except it has neither CURRENT_TERM nor VOTED_FOR.
 
 class FileJournal(Journal):
 
     def __init__(self, journalFile, flushJournal):
         self.__journalFile = ResizableFile(journalFile, defaultContent=self.__getDefaultHeader())
         self.__journal = []
+
+        # Handle journal format version upgrades
+        version = struct.unpack('<I', self.__journalFile.read(32, 4))[0]
+        if version == 1:
+            # Header size increased by 24 bytes, so everything needs to be moved...
+            tmpFile = journalFile + '.tmp'
+            if os.path.exists(tmpFile):
+                raise RuntimeError('Migration of journal file failed: {} already exists'.format(tmpFile))
+            oldJournalFile = self.__journalFile  # Just for readability
+            newJournalFile = ResizableFile(tmpFile, defaultContent=self.__getDefaultHeader())
+            oldFirstRecordOffset = NAME_SIZE + VERSION_SIZE + 4 + 4
+            oldLastRecordOffset = struct.unpack('<I', oldJournalFile.read(NAME_SIZE + VERSION_SIZE + 4, 4))[0]
+            oldCurrentOffset = oldFirstRecordOffset
+            deltaOffset = 24  # delta in record offsets between old and new format
+            while oldCurrentOffset < oldLastRecordOffset:
+                # Copy data in chunks of 4 MB (plus possibly a smaller chunk at the end)
+                d = oldJournalFile.read(oldCurrentOffset, min(4000000, oldLastRecordOffset - oldCurrentOffset))
+                if not d:
+                    # Reached EOF
+                    break
+                newJournalFile.write(oldCurrentOffset + deltaOffset, d)
+                oldCurrentOffset += len(d)
+            newJournalFile.write(LAST_RECORD_OFFSET_OFFSET, struct.pack('<I', oldLastRecordOffset + deltaOffset))
+            newJournalFile.flush()
+
+            del oldJournalFile  # Delete reference
+            self.__journalFile._destroy()
+            newJournalFile._destroy()
+            atomicReplace(tmpFile, journalFile)
+            self.__journalFile = ResizableFile(journalFile, defaultContent=self.__getDefaultHeader())
+        elif version == JOURNAL_FORMAT_VERSION:
+            # Nothing to do
+            pass
+        else:
+            raise RuntimeError('Unknown journal file version encountered: {} (expected <= {})'.format(version, JOURNAL_FORMAT_VERSION))
+
         currentOffset = FIRST_RECORD_OFFSET
         lastRecordOffset = self.__getLastRecordOffset()
         while currentOffset < lastRecordOffset:
@@ -143,7 +188,10 @@ class FileJournal(Journal):
     def __getDefaultHeader(self):
         appName = APP_NAME + b'\0' * (NAME_SIZE - len(APP_NAME))
         appVersion = APP_VERSION + b'\0' * (VERSION_SIZE - len(APP_VERSION))
-        header = appName + appVersion + struct.pack('<II', JOURNAL_FORMAT_VERSION, FIRST_RECORD_OFFSET)
+        header = (appName + appVersion + struct.pack('<I', JOURNAL_FORMAT_VERSION) +
+          struct.pack('<Q', 0) + # default term = 0
+          hashlib.md5(pickle.dumps(None)).digest() + # default voted for = empty
+          struct.pack('<I', FIRST_RECORD_OFFSET))
         return header
 
     def __getLastRecordOffset(self):

--- a/pysyncobj/syncobj.py
+++ b/pysyncobj/syncobj.py
@@ -154,7 +154,7 @@ class SyncObj(object):
         self.__votesCount = 0
         self.__raftLeader = None
         self.__raftElectionDeadline = time.time() + self.__generateRaftTimeout()
-        self.__raftLog = createJournal(self.__conf.journalFile)
+        self.__raftLog = createJournal(self.__conf.journalFile, self.__conf.flushJournal)
         if len(self.__raftLog) == 0:
             self.__raftLog.add(_bchr(_COMMAND_TYPE.NO_OP), 1, self.__raftCurrentTerm)
         self.__raftCommitIndex = 1

--- a/test_syncobj.py
+++ b/test_syncobj.py
@@ -1173,6 +1173,8 @@ def test_journal_flushing():
 	finally:
 		pysyncobj.journal.ResizableFile = origResizableFile
 
+	removeFiles(journalFiles)
+
 
 def test_autoTick1():
 	random.seed(42)


### PR DESCRIPTION
This fixes #84.

A new configuration option, `flushJournal`, controls whether the journal should be flushed to disk on every write. This is enabled by default when using a file-based journal (i.e. when `journalFile` is not `None`). It is an error to specify `flushJournal = True` for the memory-based journal.

To store the `currentTerm` and the `votedForNodeIdHash` in the journal, the header had to be expanded, which also means that the journal file format is now version 2. Migration is performed upon restarting with the upgraded code (and there's also a test for this). Regarding details about `votedForNodeIdHash` (and why this is an MD5 hash), see my recent comment in #84. The `FileJournal` now also verifies that the journal file version is supported by the code and throws a `RuntimeError` if that is not the case; previously, it simply always tried to read it as a version 1 file.

If journal flushing is disabled, the node will not take part in elections until 1.1 times the maximum timeout has elapsed. This is necessary to prevent a node from voting twice in the same election, which could lead to two leaders being elected within a single term. It can however lead to a longer delay before the cluster is operational again after failover.

This furthermore fixes a crash in the `ResizableFile` when performing a big write (compared to the current file size). See commit message of 38d6adf0 for details.