### PR TITLE
Don't try to send self address when connecting as read-only

### DIFF
--- a/test_syncobj.py
+++ b/test_syncobj.py
@@ -1211,13 +1211,13 @@ def test_readOnlyNodes():
 
     a = [getNextAddr(), getNextAddr(), getNextAddr()]
 
-    o1 = TestObj(a[0], [a[1], a[2]])
-    o2 = TestObj(a[1], [a[2], a[0]])
-    o3 = TestObj(a[2], [a[0], a[1]])
+    o1 = TestObj(a[0], [a[1], a[2]], password='123')
+    o2 = TestObj(a[1], [a[2], a[0]], password='123')
+    o3 = TestObj(a[2], [a[0], a[1]], password='123')
     objs = [o1, o2, o3]
 
-    b1 = TestObj(None, [a[0], a[1], a[2]])
-    b2 = TestObj(None, [a[0], a[1], a[2]])
+    b1 = TestObj(None, [a[0], a[1], a[2]], password='123')
+    b2 = TestObj(None, [a[0], a[1], a[2]], password='123')
 
     roObjs = [b1, b2]
 


### PR DESCRIPTION
When connecting as readonly node to the cluster with encryption enabled the _onOutgoingMessageReceived() method tried to unconditionally send _selfNode.address after an exchange of random keys.
Since the _selfNode.address is None, the following exception was raised:
```python
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pysyncobj/syncobj.py", line 505, in _autoTickThread
    self._onTick(self.__conf.autoTickPeriod)
  File "/usr/local/lib/python2.7/dist-packages/pysyncobj/syncobj.py", line 617, in _onTick
    self._poller.poll(timeToWait)
  File "/usr/local/lib/python2.7/dist-packages/pysyncobj/poller.py", line 97, in poll
    self.__descrToCallbacks[descr](descr, eventMask)
  File "/usr/local/lib/python2.7/dist-packages/pysyncobj/tcp_connection.py", line 174, in __processConnection
    self.__onMessageReceived(message)
  File "/usr/local/lib/python2.7/dist-packages/pysyncobj/transport.py", line 455, in _onOutgoingMessageReceived
    conn.send(self._selfNode.address)
AttributeError: 'NoneType' object has no attribute 'address'
```