### PR TITLE
Bugfix: use == for comparison with __selfNode instead of "is"

### DIFF
--- a/pysyncobj/syncobj.py
+++ b/pysyncobj/syncobj.py
@@ -1170,7 +1170,7 @@ class SyncObj(object):
         if adding:
             newNode = requestNode
             # Node already exists in cluster
-            if newNode is self.__selfNode or newNode in self.__otherNodes:
+            if newNode == self.__selfNode or newNode in self.__otherNodes:
                 return False
             self.__otherNodes.add(newNode)
             self.__raftNextIndex[newNode] = self.__getCurrentLogIndex() + 1
@@ -1181,7 +1181,7 @@ class SyncObj(object):
             return True
         else:
             oldNode = requestNode
-            if oldNode is self.__selfNode:
+            if oldNode == self.__selfNode:
                 return False
             if oldNode not in self.__otherNodes:
                 return False


### PR DESCRIPTION
when adding or removing cluster nodes the added node also gets added to the list of partner nodes (by replaying the journal).
Example. First I have had the cluster from only two nodes, `127.0.0.1:2222` and `127.0.0.1:2223`.
On the next step I added `127.0.0.1:2224` to the cluster and started it up.
It resulted in the following `syncobj_admin -conn 127.0.0.1:2224 -status` output:
```
commit_idx: 153
enabled_code_version: 0
last_applied: 153
leader: 127.0.0.1:2222
leader_commit_idx: 153
log_len: 6
match_idx_count: 1
match_idx_server_127.0.0.1:2224: 0
next_node_idx_count: 1
next_node_idx_server_127.0.0.1:2224: 150
partner_node_status_server_127.0.0.1:2222: 2
partner_node_status_server_127.0.0.1:2223: 2
partner_node_status_server_127.0.0.1:2224: 0  <= should not be here
partner_nodes_count: 3  <= should be 2
raft_term: 1
readonly_nodes_count: 0
revision: deprecated
self: 127.0.0.1:2224
self_code_version: 0
state: 0
uptime: 3
version: 0.3.7
```

It happened because the `__doChangeCluster()` method was using `is` operator for comparison with the __selfNode.