### PR TITLE
Use node.ip instead of host for connecting

### DIFF
--- a/pysyncobj/utility.py
+++ b/pysyncobj/utility.py
@@ -54,12 +54,6 @@ class TcpUtility(Utility):
         self.__error = None
 
     def executeCommand(self, node, command):
-        """
-        Executes command on the given node.
-        :param node: where to execute the command
-        :type node: Node or str
-        """
-
         self.__result = None
         self.__error = None
 
@@ -70,7 +64,7 @@ class TcpUtility(Utility):
                 self.__error = 'invalid address to connect'
                 return
 
-        self.__isConnected = self.__connection.connect(node.host, node.port)
+        self.__isConnected = self.__connection.connect(node.ip, node.port)
         if not self.__isConnected:
             self.__error = "can't connected"
             return


### PR DESCRIPTION
The `TcpConnection.connect()` method expects to get the IP address.

In addition to that remove forgotten docstring from TcpUtility.executeCommand(), because it is already presented in the interface class