### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     long_description=long_description,
     author='Filipp Ozinov',
     author_email='fippo@mail.ru',
+    license='MIT',
     url='https://github.com/bakwc/PySyncObj',
     download_url='https://github.com/bakwc/PySyncObj/tarball/' + VERSION,
     keywords=['network', 'replication', 'raft', 'synchronization'],


### PR DESCRIPTION
Allow third-party tools (e.g., PyPI or `pyp2rpm`) to get the license details in a simple way.