### PR TITLE
Fix disconnection when connecting

### DIFF
--- a/pysyncobj/tcp_connection.py
+++ b/pysyncobj/tcp_connection.py
@@ -152,6 +152,8 @@ class TcpConnection(object):
             if self.__state == CONNECTION_STATE.CONNECTING:
                 if self.__onConnected is not None:
                     self.__onConnected()
+                if self.__state == CONNECTION_STATE.DISCONNECTED:
+                    return
                 self.__state = CONNECTION_STATE.CONNECTED
                 self.__lastReadTime = monotonicTime()
                 return


### PR DESCRIPTION
When a peer node is quickly disconnected after connecting, the connection will be incorrectly set as connected. However, the socket is set to None, and a subsequent send() will throw an uncaught exception:
```
AttributeError: 'NoneType' object has no attribute 'send'
```

Call stack: Connection is disconnected when connecting but incorrectly set to connected:
```
[<FrameSummary file /usr/lib/python3.10/threading.py, line 966 in _bootstrap>,
 <FrameSummary file /usr/lib/python3.10/threading.py, line 1009 in _bootstrap_inner>,
 <FrameSummary file /usr/lib/python3.10/threading.py, line 946 in run>,
 <FrameSummary file /path/PySyncObj/pysyncobj/syncobj.py, line 520 in _autoTickThread>,
 <FrameSummary file /path/PySyncObj/pysyncobj/syncobj.py, line 616 in _onTick>,
 <FrameSummary file /path/PySyncObj/pysyncobj/poller.py, line 97 in poll>,
 <FrameSummary file /path/PySyncObj/pysyncobj/tcp_connection.py, line 154 in __processConnection>,
 <FrameSummary file /path/PySyncObj/pysyncobj/transport.py, line 456 in _onOutgoingConnected>,
 <FrameSummary file /path/PySyncObj/pysyncobj/transport.py, line 439 in _sendSelfAddress>,
 <FrameSummary file /path/PySyncObj/pysyncobj/tcp_connection.py, line 107 in send>,
 <FrameSummary file /path/PySyncObj/pysyncobj/tcp_connection.py, line 183 in __trySendBuffer>,
 <FrameSummary file /path/PySyncObj/pysyncobj/tcp_connection.py, line 200 in __processSend>,
 <FrameSummary file /path/PySyncObj/pysyncobj/tcp_connection.py, line 130 in disconnect>]
```

Traceback: uncaught exception:
```
Exception in thread Thread-1 (_autoTickThread):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "/path/PySyncObj/pysyncobj/syncobj.py", line 520, in _autoTickThread
    self._onTick(self.__conf.autoTickPeriod)
  File "/path/PySyncObj/pysyncobj/syncobj.py", line 566, in _onTick
    self.__transport.send(node, {
  File "/path/PySyncObj/pysyncobj/transport.py", line 565, in send
    self._connections[node].send(message)
  File "/path/PySyncObj/pysyncobj/tcp_connection.py", line 107, in send
    self.__trySendBuffer()
  File "/path/PySyncObj/pysyncobj/tcp_connection.py", line 183, in __trySendBuffer
    while self.__processSend():
  File "/path/PySyncObj/pysyncobj/tcp_connection.py", line 190, in __processSend
    res = self.__socket.send(self.__writeBuffer)
AttributeError: 'NoneType' object has no attribute 'send'
```