### PR TITLE
 Implement basic replay protection 

### DIFF
--- a/pysyncobj/tcp_connection.py
+++ b/pysyncobj/tcp_connection.py
@@ -102,7 +102,7 @@ class TcpConnection(object):
             message = (self.sendRandKey, message)
         data = zlib.compress(pickle.dumps(message), 3)
         if self.encryptor:
-            data = self.encryptor.encrypt_at_time(data, int(monotonicTime())
+            data = self.encryptor.encrypt_at_time(data, int(monotonicTime()))
         data = struct.pack('i', len(data)) + data
         self.__writeBuffer += data
         self.__trySendBuffer()

--- a/pysyncobj/tcp_connection.py
+++ b/pysyncobj/tcp_connection.py
@@ -35,6 +35,7 @@ class TcpConnection(object):
 
         self.sendRandKey = None
         self.recvRandKey = None
+        self.recvLastTimestamp = 0
         self.encryptor = None
 
         self.__socket = socket
@@ -101,7 +102,7 @@ class TcpConnection(object):
             message = (self.sendRandKey, message)
         data = zlib.compress(pickle.dumps(message), 3)
         if self.encryptor:
-            data = self.encryptor.encrypt(data)
+            data = self.encryptor.encrypt_at_time(data, int(monotonicTime())
         data = struct.pack('i', len(data)) + data
         self.__writeBuffer += data
         self.__trySendBuffer()
@@ -115,6 +116,7 @@ class TcpConnection(object):
             needCallDisconnect = True
         self.sendRandKey = None
         self.recvRandKey = None
+        self.recvLastTimestamp = 0
         if self.__socket is not None:
             self.__socket.close()
             self.__socket = None
@@ -232,12 +234,17 @@ class TcpConnection(object):
         data = self.__readBuffer[4:4 + l]
         try:
             if self.encryptor:
+                dataTimestamp = self.encryptor.extract_timestamp(data)
+                assert dataTimestamp >= self.recvLastTimestamp
+                self.recvLastTimestamp = dataTimestamp
+                # Unfortunately we can't get a timestamp and data in one go
                 data = self.encryptor.decrypt(data)
             message = pickle.loads(zlib.decompress(data))
             if self.recvRandKey:
                 randKey, message = message
                 assert randKey == self.recvRandKey
         except:
+            # Why no logging of security errors?
             self.disconnect()
             return None
         self.__readBuffer = self.__readBuffer[4 + l:]


### PR DESCRIPTION
Currently PySyncObj implements replay protection via `recvRandKey` and `sendRandKey`. This is good, but protects only when attackers open a new TCP connection or try to inject messages captured on one connection to another, but nothing prevents attackers transparently proxying our TCP connections to `replay`/`delay`/`reorder`/`drop` messages within this TCP connection arbitrarily.

This PR implements basic replay protection by enforcing monotonicity of received timestamps. This restricts `Reordering`/`replaying` for attackers only to messages with the same timestamp. `Delaying` is still possible, but the messages now have to be either dropped or, with respect to the 1 second precision of the timestamp, delivered in the original order.

Advantage of this partial protection over more effective one is that this is no change to message format. This means that connection between patched an unpatched servers will still work except connection will be closed and immediately reopened when somebody turns clocks on their unpatched servers back.

Also, strength of this protection will improve with https://github.com/fernet/spec/issues/12 .