### PR TITLE
include SyncObjConf.password in documentation

### DIFF
--- a/pysyncobj/config.py
+++ b/pysyncobj/config.py
@@ -19,8 +19,8 @@ class SyncObjConf(object):
 
     def __init__(self, **kwargs):
 
-        # Encrypt session with specified password.
-        # Install `cryptography` module to be able to set password.
+        #: Encrypt session with specified password.
+        #: Install `cryptography` module to be able to set password.
         self.password = kwargs.get('password', None)
 
         #: Disable autoTick if you want to call onTick manually.


### PR DESCRIPTION
without the ":" the password variable is not rendered in the documentation