### PR TITLE
adding the possibility to check if the tick thread is gone

### DIFF
--- a/pysyncobj/syncobj.py
+++ b/pysyncobj/syncobj.py
@@ -291,6 +291,24 @@ class SyncObj(object):
         else:
             self._doDestroy()
 
+    def tick_thread_alive(self):
+        """
+        Check if the tick thread is alive.
+        """
+        if self.__thread and self.__thread.is_alive():
+            return True
+        return False
+
+    def destroy_synchronous(self):
+        """
+        Correctly destroy SyncObj. Stop autoTickThread, close connections, etc. and ensure the threads are gone.
+        """
+        self.destroy()
+        count = 0
+        while self.tick_thread_alive():
+            time.sleep(.1)
+            count += 1
+
     def waitReady(self):
         """
         Waits until the transport is ready for operation.


### PR DESCRIPTION
If a SyncObj is destroyed the thread running _autoTickThread is terminated with a delay. Currently there is not option to check if the thread was already terminated.

This adds the option to check the alive status of this thread and also destroy the SyncObj 'synchron' by checking the thread.
If no such thread is running the tick_thread_alive method returns False, to be able to use if without considering the way it is currently running.