### PR TITLE
log exceptions in _autoTickThread and continue

### DIFF
--- a/pysyncobj/syncobj.py
+++ b/pysyncobj/syncobj.py
@@ -534,7 +534,12 @@ class SyncObj(object):
                 if self.__destroying:
                     self._doDestroy()
                     break
-                self._onTick(self.__conf.autoTickPeriod)
+                try:
+                    self._onTick(self.__conf.autoTickPeriod)
+                except Exception:
+                    # log, wait a little and retry
+                    logger.exception('failed _onTick in _autoTickThread')
+                    time.sleep(self.__conf.autoTickPeriod)
         except ReferenceError:
             pass
 


### PR DESCRIPTION
This change is an idea to fix #189. This shall make the auto tick thread more robust.
I'm not sure though if it is safe to catch and ignore all exceptions here.