### PR TITLE
propagate SyncObjException.errorCode

### DIFF
--- a/pysyncobj/syncobj.py
+++ b/pysyncobj/syncobj.py
@@ -64,7 +64,7 @@ _bchr = functools.partial(struct.pack, 'B')
 
 class SyncObjException(Exception):
     def __init__(self, errorCode, *args, **kwargs):
-        Exception.__init__(self, *args, **kwargs)
+        Exception.__init__(self, errorCode, *args, **kwargs)
         self.errorCode = errorCode
 
 class SyncObjExceptionWrongVer(SyncObjException):


### PR DESCRIPTION
With this fix the errorCode directly appears in logs:
```
>>> repr(SyncObjException('something'))
"SyncObjException('something')"
```