### PR TITLE
fix AssertError for newer but lower message idx

### DIFF
--- a/pysyncobj/config.py
+++ b/pysyncobj/config.py
@@ -5,8 +5,9 @@ class FAIL_REASON:
     MISSING_LEADER = 2      #: Leader is currently missing (leader election in progress, or no connection)
     DISCARDED = 3           #: Command discarded (cause of new leader elected and another command was applied instead)
     NOT_LEADER = 4          #: Leader has changed, old leader did not have time to commit command.
-    LEADER_CHANGED = 5      #: Simmilar to NOT_LEADER - leader has changed without command commit.
+    LEADER_CHANGED = 5      #: Similar to NOT_LEADER - leader has changed without command commit.
     REQUEST_DENIED = 6      #: Command denied
+    UNKNOWN_OUTCOME = 7     #: Unknown outcome - Unknown outcome, might happen if a older command is tried to apply
 
 class SERIALIZER_STATE:
     NOT_SERIALIZING = 0     #: Serialization not started or already finished.

--- a/pysyncobj/syncobj.py
+++ b/pysyncobj/syncobj.py
@@ -980,7 +980,7 @@ class SyncObj(object):
                         # before this response was processed. Or the leader was restarted without notice (and remains leader).
                         # The command outcome cannot be tracked; signal the caller so it can retry rather than hanging
                         # forever.
-                        callback(None, FAIL_REASON.DISCARDED)
+                        callback(None, FAIL_REASON.UNKNOWN_OUTCOME)
                     else:
                         self.__commandsWaitingCommit[idx].append((term, callback))
 

--- a/pysyncobj/syncobj.py
+++ b/pysyncobj/syncobj.py
@@ -974,8 +974,15 @@ class SyncObj(object):
                 else:
                     idx = message['log_idx']
                     term = message['log_term']
-                    assert idx > self.__raftLastApplied
-                    self.__commandsWaitingCommit[idx].append((term, callback))
+                    if idx <= self.__raftLastApplied:
+                        # Stale apply_command_response:
+                        # The log position was already applied (e.g. via snapshot installed after leader reconnect)
+                        # before this response was processed. Or the leader was restarted without notice (and remains leader).
+                        # The command outcome cannot be tracked; signal the caller so it can retry rather than hanging
+                        # forever.
+                        callback(None, FAIL_REASON.DISCARDED)
+                    else:
+                        self.__commandsWaitingCommit[idx].append((term, callback))
 
         if self.__raftState == _RAFT_STATE.CANDIDATE:
             if message['type'] == 'response_vote' and message['term'] == self.__raftCurrentTerm:


### PR DESCRIPTION
# line 975-978
```
idx = message['log_idx']
term = message['log_term']
assert idx > self.__raftLastApplied          # ← crashes here
self.__commandsWaitingCommit[idx].append((term, callback))
```

# The Race Condition

## Key triggering scenario — leader reconnects after restart with stale socket data:

1. Follower A sends `apply_command` to Leader B → `commandsWaitingReply[N] = callback`
2. Leader B logs the command at log_idx=X, sends `apply_command_response` (message in OS socket buffer, not yet read by A)
3. Leader B restarts → new TCP connection established from B → A
4. In `_onIncomingMessageReceived` (transport.py:368), the new connection replaces the old one: `self._connections[node] = new_conn`, but the old socket stays registered with the poller
5. The new connection delivers fresh `append_entries` with a snapshot → `__loadDumpFile(clearJournal=True) → __raftLastApplied` jumps past X
6. Crucially: because the reconnecting node has the same address (same Node.id), line 886 evaluates `self.__raftLeader != node` as **False** — `__onLeaderChanged()` is **never called**, so `commandsWaitingReply[N]` is not cleared
7. The old socket then delivers its buffered `apply_command_response` with `log_idx=X`
8. Callback is found in `commandsWaitingReply` → `X` > `__raftLastApplied` → **False** → **_AssertionError_**

## Secondary scenario — tick ordering:

The tick order is:
`__applyLogEntries()`  →  `__sendAppendEntries()`  →  `_checkCommandsToApply()`  →  `_poller.poll()`
If `__applyLogEntries()` applies entry at `idx=X` (advancing `__raftLastApplied` to X) in the same tick that `_poller.poll() ` delivers an `apply_command_response` with `log_idx=X`, you get X > X → False.

  # Why it "doesn't go away"
`AssertionError` is a subclass of Exception. The `_autoTickThread` has a blanket except Exception at line 539 that catches it, logs it, and continues running. The popped callback is silently dropped (never called, never put in `commandsWaitingCommit`). If the  application retries the command under the same cluster instability, it can reproduce the same race.

@bakwc Can you please confirm this fix? It is hard to reproduce reliable.