### PR TITLE
Benchmarks: support py3

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -28,7 +28,7 @@ def memoize(fileName):
     return doMemoize
 
 def singleBenchmark(requestsPerSecond, requestSize, numNodes, numNodesReadonly = 0, delay = False):
-    rpsPerNode = requestsPerSecond / (numNodes + numNodesReadonly)
+    rpsPerNode = int(requestsPerSecond / (numNodes + numNodesReadonly))
     cmd = [sys.executable, 'testobj_delay.py' if delay else 'testobj.py', str(rpsPerNode), str(requestSize)]
     #cmd = 'python2.7 -m cProfile -s time testobj.py %d %d' % (rpsPerNode, requestSize)
     processes = []
@@ -75,7 +75,7 @@ def detectMaxRps(requestSize, numNodes):
         res = doDetectMaxRps(requestSize, numNodes)
         print('iteration %d, current max %d' % (i, res))
         results.append(res)
-    return sorted(results)[len(results) / 2]
+    return sorted(results)[int(len(results) / 2)]
 
 def printUsage():
     print('Usage: %s mode(delay/rps/custom)' % sys.argv[0])

--- a/benchmarks/testobj.py
+++ b/benchmarks/testobj.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
 
     while time.time() - startTime < 25.0:
         st = time.time()
-        for i in xrange(0, numCommands):
+        for i in range(0, numCommands):
             obj.testMethod(getRandStr(cmdSize), callback=clbck)
             _g_sent += 1
         delta = time.time() - st

--- a/benchmarks/testobj_delay.py
+++ b/benchmarks/testobj_delay.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
 
     while time.time() - startTime < 25.0:
         st = time.time()
-        for i in xrange(0, numCommands):
+        for i in range(0, numCommands):
             obj.testMethod(getRandStr(cmdSize), time.time(), callback=clbck)
             _g_sent += 1
         delta = time.time() - st
@@ -83,7 +83,7 @@ if __name__ == '__main__':
     print('SUCCESS RATE:', successRate)
 
     delays = sorted(_g_delays)
-    avgDelay = _g_delays[len(_g_delays) / 2]
+    avgDelay = _g_delays[int(len(_g_delays) / 2)]
     print('AVG DELAY:', avgDelay)
 
     if successRate < 0.9:


### PR DESCRIPTION
While testing https://github.com/bakwc/PySyncObj/pull/197 , tried to run benchmarks, here are minor fixes to basically run them on py3.

FWIW, with https://github.com/bakwc/PySyncObj/pull/197 I can consistently see `raftCommitIndex (147033) exceeds journal end (136326) after loading dump, likely due to unsynced journal entries lost on crash; clamping to journal end
` warnings on large RPS.