### PR TITLE
Fix ResizableFile.write() crash when a single resize is not enough

### DIFF
--- a/pysyncobj/journal.py
+++ b/pysyncobj/journal.py
@@ -90,17 +90,18 @@ class ResizableFile(object):
         if currSize < initialSize:
             try:
                 self.__mm.resize(initialSize)
-            except SystemError:
+            except (SystemError, OSError):
                 self.__extand(initialSize - currSize)
 
     def write(self, offset, values):
         size = len(values)
-        currSize = self.__mm.size()
-        if offset + size > self.__mm.size():
+        while offset + size > self.__mm.size():
+            currSize = self.__mm.size()
+            newSize = max(int(currSize * self.__resizeFactor), offset + size)
             try:
-                self.__mm.resize(int(self.__mm.size() * self.__resizeFactor))
-            except SystemError:
-                self.__extand(int(self.__mm.size() * self.__resizeFactor) - currSize)
+                self.__mm.resize(newSize)
+            except (SystemError, OSError):
+                self.__extand(newSize - currSize)
         self.__mm[offset:offset + size] = values
 
     def read(self, offset, size):


### PR DESCRIPTION
## What breaks and why

`ResizableFile.write()` contains two bugs that together cause an
`IndexError: mmap slice assignment is wrong size` crash on Linux when a
late-joining raft node receives its first large catch-up batch from the leader.

### Bug 1 — `if` instead of `while` (wrong size after one resize)

```python
# before
if offset + size > self.__mm.size():
    self.__mm.resize(int(self.__mm.size() * self.__resizeFactor))  # doubles once
self.__mm[offset:offset + size] = values  # ← IndexError if still too small
```

`resizeFactor` is `2.0`, so the mmap doubles once. If the value being
written is larger than `2 × current_mmap_size`, one doubling is not
enough and the assignment crashes.

**Concrete example (Patroni / pysyncobj 0.3.15, Ubuntu 24.04, Python 3.12):**
The journal starts at 1 KB (`initialSize=1024`). When a new node joins an
existing 3-node cluster it receives the full committed raft log as a
catch-up batch. That batch includes the initial DCS bootstrap config
(PostgreSQL parameters, pg_hba, etc.) which serialises to several KB.
The first write is at offset 40 with `size ≈ 3–5 KB`. One resize brings
the mmap to 2 KB — still too small — and the write crashes.

### Bug 2 — `except SystemError` misses `OSError` on Linux / Python 3

```python
try:
    self.__mm.resize(newSize)
except SystemError:       # ← never triggered on Linux
    self.__extand(...)    # ← fallback never runs
```

On Linux with Python 3, `mmap.resize()` calls `ftruncate` + `mremap`.
When `mremap` fails it raises **`OSError`**, not `SystemError`. The
`__extand` fallback that re-opens the file is therefore silently skipped
on every Linux deployment, leaving the mmap at its original size.

## Fix

1. Change `if` → `while` so we keep resizing until the mmap is actually
   large enough.
2. Use `max(doubled_size, offset + size)` so a single iteration always
   covers arbitrarily large values without looping.
3. Catch `(SystemError, OSError)` in both resize call-sites so the
   `__extand` fallback works on Linux.

```python
# after
while offset + size > self.__mm.size():
    currSize = self.__mm.size()
    newSize = max(int(currSize * self.__resizeFactor), offset + size)
    try:
        self.__mm.resize(newSize)
    except (SystemError, OSError):
        self.__extand(newSize - currSize)
self.__mm[offset:offset + size] = values
```

## How to reproduce

Start a 3-node pysyncobj/Patroni cluster simultaneously. The third node
to join (which receives the catch-up batch rather than bootstrapping from
scratch) will log:

```
IndexError: mmap slice assignment is wrong size
  File ".../pysyncobj/journal.py", line 104, in write
    self.__mm[offset:offset + size] = values
```

and then loop indefinitely unable to reach the leader, while the other
two nodes operate normally.

Observed with: pysyncobj 0.3.15, Patroni 4.1.3, Python 3.12, Ubuntu 24.04 (Linux 6.x, KVM).